### PR TITLE
ms edge fix for href in <a>

### DIFF
--- a/popover.es6.js
+++ b/popover.es6.js
@@ -152,6 +152,7 @@ Template.iosPopover.events({
         // we can not add the class to click handler, because blaze bug (https://github.com/meteor/meteor/issues/2981)
         // otherwise we can get a "Must be attached" Error from Blaze.
         if ($(event.target).hasClass('ios-popover-backdrop')) {
+            event.preventDefault(true);
             IosPopover.hide();
         }
     }

--- a/popover.html
+++ b/popover.html
@@ -1,5 +1,5 @@
 <template name="iosPopover">
-  <a class="ios-popover-backdrop {{id}}" href=''> {{! we need this empty href to support click events on ios }}
+  <a class="ios-popover-backdrop {{id}}" href='#'> {{! we need this empty href to support click events on ios }}
     <div class="ios-popover-wrapper" id="{{id}}">
       <div class="ios-popover">
         <div class="ios-popover-arrow"></div>


### PR DESCRIPTION
fix 'no route found' bug in edge: add '#' to empty href, event.preventDefault.
